### PR TITLE
Updating mailing list URLs

### DIFF
--- a/0001/README.md
+++ b/0001/README.md
@@ -3,7 +3,7 @@
 * Assistant Professor at the University of Illinois, Urbana-Champaign
 * Chair of the Zcash Foundation Board
 * https://soc1024.com/
-* Mailing list post: https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000007.html
+* Mailing list post: https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000007.html
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0002/README.md
+++ b/0002/README.md
@@ -3,7 +3,7 @@
 * Software engineer
 * Founder of [PlutoMonkey](https://www.plutomonkey.com)
 * <https://www.jasondavies.com>
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000009.html>.
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000009.html>.
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0003/README.md
+++ b/0003/README.md
@@ -2,7 +2,7 @@
 
 * Principal @ Pushforward Limited
 * https://jtobin.io
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000013.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000013.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0004/README.md
+++ b/0004/README.md
@@ -2,7 +2,7 @@
 
 * Software Engineer
 * https://matt.drollette.com/
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000018.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000018.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0005/README.md
+++ b/0005/README.md
@@ -1,7 +1,7 @@
 # Kobi Gurkan
 
 * QED-it
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000023.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000023.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0006/README.md
+++ b/0006/README.md
@@ -1,6 +1,6 @@
 # Hudson Jameson and Steven Schroeder
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000041.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000041.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0007/README.md
+++ b/0007/README.md
@@ -1,6 +1,6 @@
 # Eric L. Stromberg
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000044.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000044.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0008/README.md
+++ b/0008/README.md
@@ -1,6 +1,6 @@
 # Cody Burns
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000045.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000045.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0009/README.md
+++ b/0009/README.md
@@ -1,7 +1,7 @@
 # Robert Hackett
 
 * Reporter at Fortune
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000063.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000063.html>
 * https://keybase.io/rhhackett
 * See `./report.asc` for the signed attestation.
 

--- a/0010/README.md
+++ b/0010/README.md
@@ -1,6 +1,6 @@
 # Michael Dixon
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000067.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000067.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0011/README.md
+++ b/0011/README.md
@@ -1,7 +1,7 @@
 # [Adrian Brink](https://adrianbrink.com/)
 
 * Core Developer @ [Cosmos Network](https://cosmos.network/)
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000069.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000069.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0012/README.md
+++ b/0012/README.md
@@ -2,7 +2,7 @@
 
 * Assistant professor, Universidad de Zaragoza
 * https://riemann.unizar.es/~mmarco/
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000073.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000073.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0013/README.md
+++ b/0013/README.md
@@ -1,6 +1,6 @@
 # Tommaso Pellizzari
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000082.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000082.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0015/README.md
+++ b/0015/README.md
@@ -1,6 +1,6 @@
 # Adam Nagel
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000088.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000088.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0016/README.md
+++ b/0016/README.md
@@ -1,6 +1,6 @@
 # Gabor Losonci
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000090.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000090.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0017/README.md
+++ b/0017/README.md
@@ -1,7 +1,7 @@
 # Wei Tang
 
 * https://that.world/~wei
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000092.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000092.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0018/README.md
+++ b/0018/README.md
@@ -1,6 +1,6 @@
 # Neal Jayu
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000102.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000102.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0019/README.md
+++ b/0019/README.md
@@ -1,6 +1,6 @@
 # Adam Langley
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000100.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000100.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0021/README.md
+++ b/0021/README.md
@@ -1,6 +1,6 @@
 # Rudi Cilibrasi
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-November/000103.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000103.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:

--- a/0023/README.md
+++ b/0023/README.md
@@ -1,6 +1,6 @@
 # Justin Drake
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-December/000108.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000108.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:

--- a/0024/README.md
+++ b/0024/README.md
@@ -1,6 +1,6 @@
 # minezcash
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017-December/000119.html>
+* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000119.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:


### PR DESCRIPTION
Most _Mailing list post_ URLs are broken (probably some change on Mailman's conf?). I used sed to update all the README files: 

`find -path "./00*/README.md" -exec sed -i -E "s/2017-(November|December)/2017/g" {} +`
