### PR TITLE
lists.z.cash.foundation has moved to lists.zfnd.org

### DIFF
--- a/0001/README.md
+++ b/0001/README.md
@@ -3,7 +3,7 @@
 * Assistant Professor at the University of Illinois, Urbana-Champaign
 * Chair of the Zcash Foundation Board
 * https://soc1024.com/
-* Mailing list post: https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000007.html
+* Mailing list post: https://lists.zfnd.org/pipermail/zapps-wg/2017/000007.html
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0002/README.md
+++ b/0002/README.md
@@ -3,7 +3,7 @@
 * Software engineer
 * Founder of [PlutoMonkey](https://www.plutomonkey.com)
 * <https://www.jasondavies.com>
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000009.html>.
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000009.html>.
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0003/README.md
+++ b/0003/README.md
@@ -2,7 +2,7 @@
 
 * Principal @ Pushforward Limited
 * https://jtobin.io
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000013.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000013.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0004/README.md
+++ b/0004/README.md
@@ -2,7 +2,7 @@
 
 * Software Engineer
 * https://matt.drollette.com/
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000018.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000018.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0005/README.md
+++ b/0005/README.md
@@ -1,7 +1,7 @@
 # Kobi Gurkan
 
 * QED-it
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000023.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000023.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0006/README.md
+++ b/0006/README.md
@@ -1,6 +1,6 @@
 # Hudson Jameson and Steven Schroeder
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000041.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000041.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0007/README.md
+++ b/0007/README.md
@@ -1,6 +1,6 @@
 # Eric L. Stromberg
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000044.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000044.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0008/README.md
+++ b/0008/README.md
@@ -1,6 +1,6 @@
 # Cody Burns
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000045.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000045.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0009/README.md
+++ b/0009/README.md
@@ -1,7 +1,7 @@
 # Robert Hackett
 
 * Reporter at Fortune
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000063.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000063.html>
 * https://keybase.io/rhhackett
 * See `./report.asc` for the signed attestation.
 

--- a/0010/README.md
+++ b/0010/README.md
@@ -1,6 +1,6 @@
 # Michael Dixon
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000067.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000067.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0011/README.md
+++ b/0011/README.md
@@ -1,7 +1,7 @@
 # [Adrian Brink](https://adrianbrink.com/)
 
 * Core Developer @ [Cosmos Network](https://cosmos.network/)
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000069.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000069.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0012/README.md
+++ b/0012/README.md
@@ -2,7 +2,7 @@
 
 * Assistant professor, Universidad de Zaragoza
 * https://riemann.unizar.es/~mmarco/
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000073.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000073.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0013/README.md
+++ b/0013/README.md
@@ -1,6 +1,6 @@
 # Tommaso Pellizzari
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000082.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000082.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0015/README.md
+++ b/0015/README.md
@@ -1,6 +1,6 @@
 # Adam Nagel
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000088.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000088.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0016/README.md
+++ b/0016/README.md
@@ -1,6 +1,6 @@
 # Gabor Losonci
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000090.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000090.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0017/README.md
+++ b/0017/README.md
@@ -1,7 +1,7 @@
 # Wei Tang
 
 * https://that.world/~wei
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000092.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000092.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0018/README.md
+++ b/0018/README.md
@@ -1,6 +1,6 @@
 # Neal Jayu
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000102.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000102.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0019/README.md
+++ b/0019/README.md
@@ -1,6 +1,6 @@
 # Adam Langley
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000100.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000100.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0021/README.md
+++ b/0021/README.md
@@ -1,6 +1,6 @@
 # Rudi Cilibrasi
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000103.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000103.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:

--- a/0023/README.md
+++ b/0023/README.md
@@ -1,6 +1,6 @@
 # Justin Drake
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000108.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000108.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:

--- a/0024/README.md
+++ b/0024/README.md
@@ -1,6 +1,6 @@
 # minezcash
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000119.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000119.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:

--- a/0025/README.md
+++ b/0025/README.md
@@ -1,6 +1,6 @@
 # Fabrice Marchal
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000131.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000131.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:

--- a/0026/README.md
+++ b/0026/README.md
@@ -1,6 +1,6 @@
 # Gareth Davies
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000133.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000133.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:

--- a/0028/README.md
+++ b/0028/README.md
@@ -1,6 +1,6 @@
 # SuperKerem
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2017/000143.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2017/000143.html>
 * See `./report.asc` for a signed attestation.
 
 Response file:

--- a/0029/README.md
+++ b/0029/README.md
@@ -1,6 +1,6 @@
 # Tony Arcieri
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000149.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000149.html>
 * https://twitter.com/bascule/status/948285074872532992
 
 Response file:

--- a/0030/README.md
+++ b/0030/README.md
@@ -1,6 +1,6 @@
 # Junajpu
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000168.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000168.html>
 
 Response file:
 

--- a/0031/README.md
+++ b/0031/README.md
@@ -1,6 +1,6 @@
 # Brian Gomes Bascoy
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000176.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000176.html>
 
 Response file:
 

--- a/0032/README.md
+++ b/0032/README.md
@@ -1,6 +1,6 @@
 # James Prestwich
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000179.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000179.html>
 * See `./report.asc` for signed attestation.
 
 Response file:

--- a/0033/README.md
+++ b/0033/README.md
@@ -1,6 +1,6 @@
 # Nick Sullivan
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000186.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000186.html>
 * See `./response.asc` for the signature of the `response` file.
 
 Response file:

--- a/0034/README.md
+++ b/0034/README.md
@@ -1,6 +1,6 @@
 # Deyan Ginev
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000187.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000187.html>
 
 Response file:
 

--- a/0036/README.md
+++ b/0036/README.md
@@ -1,6 +1,6 @@
 # Chris Baynes
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000195.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000195.html>
 * https://twitter.com/binaryexp/status/953072048393334784
 
 Response file:

--- a/0037/README.md
+++ b/0037/README.md
@@ -1,7 +1,7 @@
 # David Campbell
 
 * https://about.me/davidcampbell
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000199.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000199.html>
 
 Response file:
 

--- a/0038/README.md
+++ b/0038/README.md
@@ -1,6 +1,6 @@
 # Ryan Close
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000201.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000201.html>
 * https://twitter.com/closerm/status/953816452997500929
 
 Response file:

--- a/0039/README.md
+++ b/0039/README.md
@@ -1,6 +1,6 @@
 # Bastien Teinturier
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000207.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000207.html>
 
 Response file:
 

--- a/0040/README.md
+++ b/0040/README.md
@@ -1,6 +1,6 @@
 # Daniel Benarroch
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000214.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000214.html>
 
 Response file:
 

--- a/0045/README.md
+++ b/0045/README.md
@@ -1,6 +1,6 @@
 # Filippo Valsorda
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000225.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000225.html>
 
 Response file:
 

--- a/0049/README.md
+++ b/0049/README.md
@@ -1,6 +1,6 @@
 # Justin Scholz
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000238.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000238.html>
 * https://twitter.com/JMoVS/status/959604676525264901
 
 Response file:

--- a/0052/README.md
+++ b/0052/README.md
@@ -1,6 +1,6 @@
 # Gustavo Frederico
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000243.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000243.html>
 
 Response file:
 

--- a/0053/README.md
+++ b/0053/README.md
@@ -1,6 +1,6 @@
 # Mark Giannullo
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000246.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000246.html>
 * https://twitter.com/markgiannullo/status/961683650210402304
 
 Response file:

--- a/0054/README.md
+++ b/0054/README.md
@@ -1,7 +1,7 @@
 # Jan Jancar
 
 * This participant provided two response files in sequence.
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000249.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000249.html>
 * See `./report.asc` for the signed attestation.
 
 Response files:

--- a/0055/README.md
+++ b/0055/README.md
@@ -2,7 +2,7 @@
 
 * <https://jobin212.github.io/>
 * <https://keybase.io/puffinrng>
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000252.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000252.html>
 
 Response file:
 

--- a/0056/README.md
+++ b/0056/README.md
@@ -2,7 +2,7 @@
 
 * Twitter: <https://twitter.com/alokmenghrajani/status/963212918505447424>
 * Co-worker's twitter: <https://twitter.com/wmcc_/status/963218431045545985>
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000256.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000256.html>
 
 Response file:
 

--- a/0057/README.md
+++ b/0057/README.md
@@ -1,6 +1,6 @@
 # Sean Kelly
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000259.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000259.html>
 
 Response file:
 

--- a/0058/README.md
+++ b/0058/README.md
@@ -1,6 +1,6 @@
 # disturbedsquirrel
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000263.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000263.html>
 
 Response file:
 

--- a/0059/README.md
+++ b/0059/README.md
@@ -1,6 +1,6 @@
 # Salvatore Testa
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000269.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000269.html>
 * Twitter: <https://twitter.com/SalTesta14/status/964925875111182336>
 * Blog post: <https://saltesta.com/crypto/powers-of-tau/>
 

--- a/0060/README.md
+++ b/0060/README.md
@@ -1,6 +1,6 @@
 # Philip Stehlik
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000273.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000273.html>
 
 Response file:
 

--- a/0061/README.md
+++ b/0061/README.md
@@ -1,6 +1,6 @@
 # Sean Bowe
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000275.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000275.html>
 
 Response file:
 

--- a/0062/README.md
+++ b/0062/README.md
@@ -1,6 +1,6 @@
 # Quentin Roberts
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000277.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000277.html>
 
 Response file:
 

--- a/0063/README.md
+++ b/0063/README.md
@@ -1,6 +1,6 @@
 # Lucas Vogelsang
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000279.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000279.html>
 
 Response file:
 

--- a/0064/README.md
+++ b/0064/README.md
@@ -1,6 +1,6 @@
 # Troy Stackhouse
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000280.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000280.html>
 
 Response file:
 

--- a/0065/README.md
+++ b/0065/README.md
@@ -1,6 +1,6 @@
 # Allieri Tommaso
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000282.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000282.html>
 
 Response file:
 

--- a/0066/README.md
+++ b/0066/README.md
@@ -1,6 +1,6 @@
 # Mikael Johansson
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000286.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000286.html>
 * <https://twitter.com/johanssonlc>
 
 Response file:

--- a/0067/README.md
+++ b/0067/README.md
@@ -1,6 +1,6 @@
 # Ryan Greenawalt
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000285.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000285.html>
 * Twitter: <https://twitter.com/NomAnor100/status/969751862713909249>
 * Gab: <https://gab.ai/NomEnt/posts/20876435>
 

--- a/0068/README.md
+++ b/0068/README.md
@@ -1,6 +1,6 @@
 # Chase Roberts
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000320.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000320.html>
 * Twitter: <https://twitter.com/TheNerdStation/status/970355374619529222>
 
 Response file:

--- a/0069/README.md
+++ b/0069/README.md
@@ -1,6 +1,6 @@
 # Boris Verhovsky
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000295.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000295.html>
 
 Response file:
 

--- a/0070/README.md
+++ b/0070/README.md
@@ -1,6 +1,6 @@
 # Zcash FR
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000319.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000319.html>
 
 Response file:
 

--- a/0071/README.md
+++ b/0071/README.md
@@ -1,6 +1,6 @@
 # Erwan Ounn
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000299.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000299.html>
 
 Response file:
 

--- a/0072/README.md
+++ b/0072/README.md
@@ -1,6 +1,6 @@
 # Libby Kent
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000313.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000313.html>
 * Twitter: <https://twitter.com/viskobatz/status/972008427458240512>
 * Input collection script: <https://github.com/libby/mixingpot>
 

--- a/0073/README.md
+++ b/0073/README.md
@@ -1,6 +1,6 @@
 # Marco Giglio
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000301.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000301.html>
 
 Response file:
 

--- a/0075/README.md
+++ b/0075/README.md
@@ -3,7 +3,7 @@
 * Former DevOps engineer for [Zcash Company](https://z.zcash)
 * Former sysadmin for [Freedom of the Press Foundation](https://freedom.press) and SRE at Cloudflare
 * Personal website: [cointel.pro](https://cointel.pro)
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000352.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000352.html>
 * See `./report.asc` for the signed attestation.
 
 Response file:

--- a/0076/README.md
+++ b/0076/README.md
@@ -1,6 +1,6 @@
 # Monica Quaintance
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000321.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000321.html>
 * Twitter: <https://twitter.com/QuaintM/status/972961152593465344>
 
 Response file:

--- a/0077/README.md
+++ b/0077/README.md
@@ -1,6 +1,6 @@
 # Lucas E Morales
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000322.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000322.html>
 * Mastodon: <https://mastodon.mit.edu/@lucasem/99669377294120258>
 * PGP public key: <https://lucasem.com/pgp>
 

--- a/0078/README.md
+++ b/0078/README.md
@@ -1,6 +1,6 @@
 # Devrandom
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000331.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000331.html>
 
 Response file:
 

--- a/0079/README.md
+++ b/0079/README.md
@@ -1,6 +1,6 @@
 # Josh Cincinnati
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000326.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000326.html>
 * Twitter: <https://twitter.com/acityinohio/status/973386393069105152>
 
 Response file:

--- a/0080/README.md
+++ b/0080/README.md
@@ -1,6 +1,6 @@
 # Ryan Taylor
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000330.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000330.html>
 * Twitter: <https://twitter.com/AdjyLeak/status/973629370593169408>
 
 Response file:

--- a/0081/README.md
+++ b/0081/README.md
@@ -1,6 +1,6 @@
 # Tiago Simoes
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000333.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000333.html>
 
 Response file:
 

--- a/0082/README.md
+++ b/0082/README.md
@@ -1,6 +1,6 @@
 # Gabor Losonci
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000334.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000334.html>
 
 Response file:
 

--- a/0084/README.md
+++ b/0084/README.md
@@ -1,6 +1,6 @@
 # Sunny Aggarwal
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000335.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000335.html>
 * Twitter: <https://twitter.com/sunnya97/status/974323886962683905>
 
 Response file:

--- a/0085/README.md
+++ b/0085/README.md
@@ -1,6 +1,6 @@
 # Amber Baldet and Patrick Nielsen
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000336.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000336.html>
 * Blog post: <https://patrickmn.com/security/hidden-in-plain-sight/>
 * Twitter: <https://twitter.com/pmylund/status/975176253044084736>
 

--- a/0086/README.md
+++ b/0086/README.md
@@ -1,6 +1,6 @@
 # Devrandom
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000338.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000338.html>
 
 Response file:
 

--- a/0087/README.md
+++ b/0087/README.md
@@ -1,6 +1,6 @@
 # John DOBBERTIN
 
-* Mailing list post: <https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000348.html>
+* Mailing list post: <https://lists.zfnd.org/pipermail/zapps-wg/2018/000348.html>
 * Participated in the first Zcash MPC ceremony: <https://archive.org/details/zc_ceremony_hash_record_LJUBLJANA>
 
 Response file:

--- a/0088/README.md
+++ b/0088/README.md
@@ -1,6 +1,6 @@
 # Random Beacon
 
-* Mailing list post: https://lists.z.cash.foundation/pipermail/zapps-wg/2018/000337.html
+* Mailing list post: https://lists.zfnd.org/pipermail/zapps-wg/2018/000337.html
 * [Signed announcement of the beacon](./beacon.txt.asc)
 * [Timestamp](./beacon.txt.asc.ots) of the beacon using [OpenTimestamps](https://opentimestamps.org/)
 


### PR DESCRIPTION
Note that the instance in `0088/beacon.txt.asc` has not been changed since that would invalidate the signature.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>